### PR TITLE
Remove Forced Fee Example

### DIFF
--- a/_includes/checkout-buttons/transaction_fee_required.html
+++ b/_includes/checkout-buttons/transaction_fee_required.html
@@ -1,3 +1,0 @@
-<div class="button-wrapper">
-  <script src="https://checkout.paymentspring.com/js/paymentspring.js" formid="96065be529990c07f205"></script>
-</div>

--- a/index.md
+++ b/index.md
@@ -19,11 +19,9 @@ dynamic amount:
 recurring checkbox:
 {% include checkout-buttons/checkbox.html %}
 
-optional transaction fee:
+optional additional donation:
+(only available to charitable, social service, and religious organizations)
 {% include checkout-buttons/transaction_fee_optional.html %}
-
-required transaction fee:
-{% include checkout-buttons/transaction_fee_required.html %}
 
 static distribution:
 {% include checkout-buttons/static-distribution.html %}


### PR DESCRIPTION
This PR removes the forced fee example as well as updates the wording surrounding our transaction fee feature and its availability. 

These are the two MCCs we will allow to utilize this feature:
8398 - Charitable and Social Service Organizations
8661 - Religious Organizations

![screen shot 2017-11-03 at 9 56 30 am](https://user-images.githubusercontent.com/25202898/32380624-831816d0-c07e-11e7-9f78-67cfd29c70f0.png)
