### PR TITLE
Added JS Callback Information

### DIFF
--- a/_includes/shared-copy/example-js-callback.html
+++ b/_includes/shared-copy/example-js-callback.html
@@ -1,0 +1,44 @@
+If you like, you can also specify a Javascript callback to fire upon a
+transaction being successfully submitted through your {{ include.type }}.
+
+Start by creating and then including in global scope your JS callback, which
+should take, as an argument, the response object:
+
+```javascript
+function myAwesomeCallback(response) {
+  console.log(response.data.amount_settled);
+}
+```
+
+You will then add `callback="myAwesomeCallback"` as an attribute of your
+`script` tag (note that we are passing it as a function, rather than calling
+it; note also that you can name this callback whatever you want):
+
+```markdown
+<script
+  src="https://checkout.paymentspring.com/js/paymentspring.js"
+  formId="cb7eae32763131ade35f"
+  callback="myAwesomeCallback"
+></script>
+```
+
+The response object we pass into the callback has a `success` boolean attribute
+as well as a `data` attribute, which in turn is a JSON object that matches the
+response from our [charge a
+token](https://paymentspring.com/developers/#charge-a-token) endpoint (see the
+"Sample Responses" tab).
+
+<script>
+function myAwesomeCallback(response) {
+  alert(response.data.amount_settled);
+};
+</script>
+
+See it in action below.
+
+<div class="button-wrapper">
+  <script formId="f345a6b9236fc0f6665f"
+    src="https://checkout.paymentspring.com/js/paymentspring.js"
+    callback="myAwesomeCallback"
+  ></script>
+</div>

--- a/_includes/shared-copy/example-script-tag.html
+++ b/_includes/shared-copy/example-script-tag.html
@@ -1,6 +1,7 @@
 To include a {{ include.type }} on a page, you will need a checkout form-id. Once you have a form-id, paste this javascript into your site where you would like the form to appear:
 
 ```markdown
-<script src="https://checkout.paymentspring.com/js/paymentspring.js" formId="cb7eae32763131ade35f"></script>
+<script src="https://checkout.paymentspring.com/js/paymentspring.js" formId="cb7eae32763131ade35f" ></script>
 ```
+
 Where `cb7eae32763131ade35f` is replaced with your form-id.

--- a/index.md
+++ b/index.md
@@ -1,8 +1,10 @@
 ## paymentspring checkout button
 
-The checkout button is the easiest way to start accepting payments on your website with paymentspring.
+The checkout button is the easiest way to start accepting payments on your
+website with paymentspring.
 
-Checkout buttons are configurable (see options below), and multiple checkout buttons can be included on a single web page.
+Checkout buttons are configurable (see options below), and multiple checkout
+buttons can be included on a single web page.
 
 ### Example
 
@@ -29,7 +31,12 @@ static distribution:
 dynamic distribution:
 {% include checkout-buttons/dynamic-distribution.html %}
 
+### Javascript callback
+
+{% include shared-copy/example-js-callback.html type="button" %}
 
 ### Support or Contact
 
-Just getting started with paymentspring, or having a problem? [Contact us](https://paymentspring.com/contact/) or checkout [our docs](https://paymentspring.com/developers/)!
+Just getting started with paymentspring, or having a problem? [Contact
+us](https://paymentspring.com/contact/) or checkout [our
+docs](https://paymentspring.com/developers/)!

--- a/inline.md
+++ b/inline.md
@@ -1,16 +1,22 @@
 ## paymentspring checkout form
 
-The checkout form is a simple way to seamlessly integrate the checkout button's ease of use natively into your site.
+The checkout form is a simple way to seamlessly integrate the checkout button's
+ease of use natively into your site.
 
-The form elements are placed along side your html making the form part of your user experience and ultimately gives you the control.
+The form elements are placed along side your html making the form part of your
+user experience and ultimately gives you the control.
 
-Each form is configurable with all the options found on our [button examples page](https://paymentspring.github.io/checkout-examples/).
+Each form is configurable with all the options found on our [button examples
+page](https://paymentspring.github.io/checkout-examples/), including the
+Javascript callback.
 
 ### Example
 
 {% include shared-copy/example-script-tag.html type="form" %}
 
-In addition to the javascript above, you will need to paste a link to our stylesheet (css) in the head of your site. If you plan to style the form, see styling below, please place this link before other css links.
+In addition to the javascript above, you will need to paste a link to our
+stylesheet (css) in the head of your site. If you plan to style the form, see
+styling below, please place this link before other css links.
 
 ```markdown
 <link rel="stylesheet" type="text/css" href="https://checkout.paymentspring.com/assets/application.css">
@@ -20,9 +26,13 @@ In addition to the javascript above, you will need to paste a link to our styles
 
 ### Styling
 
-One of the cool things about using the inline checkout form is that it is completely customizable to fit your site. By including the link to our stylesheet before your own you can easily override css rules to add colors, change sizes, and make our form your own.
+One of the cool things about using the inline checkout form is that it is
+completely customizable to fit your site. By including the link to our
+stylesheet before your own you can easily override css rules to add colors,
+change sizes, and make our form your own.
 
-Here is an example that updates the inline checkout form to match the colors of the page.
+Here is an example that updates the inline checkout form to match the colors of
+the page.
 
 {% include inline-checkout/inline-example-image.html %}
 
@@ -98,4 +108,6 @@ $light-orange: #f3a386;
 
 ### Support or Contact
 
-Just getting started with paymentspring, or having a problem? [Contact us](https://paymentspring.com/contact/) or checkout [our docs](https://paymentspring.com/developers/)!
+Just getting started with paymentspring, or having a problem? [Contact
+us](https://paymentspring.com/contact/) or checkout [our
+docs](https://paymentspring.com/developers/)!


### PR DESCRIPTION
We now have information about creating the JS callback for the checkout button/form, as well as an example. I included the example itself on the Button page, with a reference from the Form page.

Given this form submission:

![screen shot 2017-11-07 at 3 00 33 pm](https://user-images.githubusercontent.com/714518/32517805-24de3412-c3cd-11e7-9b92-ea80159562f3.png)

We get this response:

![screen shot 2017-11-07 at 3 00 43 pm](https://user-images.githubusercontent.com/714518/32517808-26888ba0-c3cd-11e7-9759-98046ee58851.png)
